### PR TITLE
Add support for parent selector extensions (`&-foo`).

### DIFF
--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -11,6 +11,7 @@ import {
   getRegularClassesMap,
   getComposesClassesMap,
   getExtendClassesMap,
+  getParentSelectorClassesMap,
   eliminateGlobals,
 } from './traversalUtils';
 
@@ -75,6 +76,12 @@ export const getStyleClasses = (filePath: string): ?Object => {
   const classesMap = getRegularClassesMap(ast);
   const composedClassesMap = getComposesClassesMap(ast);
   const extendClassesMap = getExtendClassesMap(ast);
+  const parentSelectorClassesMap = getParentSelectorClassesMap(ast);
 
-  return { ...classesMap, ...composedClassesMap, ...extendClassesMap };
+  return {
+    ...classesMap,
+    ...composedClassesMap,
+    ...extendClassesMap,
+    ...parentSelectorClassesMap
+  };
 };

--- a/lib/core/traversalUtils.js
+++ b/lib/core/traversalUtils.js
@@ -86,6 +86,81 @@ export const getExtendClassesMap = (ast: gASTNode): classMapType => {
   )(extendNodes);
 };
 
+/**
+ * Resolves parent selectors to their full class names.
+ *
+ * E.g. `.foo { &_bar {color: blue } }` to `.foo_bar`.
+ */
+export const getParentSelectorClassesMap = (ast: gASTNode): classMapType => {
+  const classesMap: classMapType = {};
+
+  // Recursively traverses down the tree looking for parent selector
+  // extensions. Recursion is necessary as these selectors can be nested.
+  const getExtensions = nodeContent => {
+    const rulesetContent = fp.compose(
+      fp.flatMap('content'),
+      fp.filter({ type: 'ruleset' }),
+      fp.flatMap('content'),
+      fp.filter({ type: 'block' })
+    )(nodeContent);
+
+    const extensions = fp.compose(
+      fp.map('content'),
+      fp.filter({ type: 'ident' }),
+      fp.flatMap('content'),
+      fp.filter({ type: 'parentSelectorExtension' }),
+      fp.flatMap('content'),
+      fp.filter({ type: 'selector' })
+    )(rulesetContent);
+
+    if (!extensions.length) return [];
+
+    const innerExtensions = getExtensions(rulesetContent);
+    const result = extensions;
+    if (innerExtensions.length) {
+      innerExtensions.forEach(innerExt => {
+        extensions.forEach(ext => {
+          result.push(ext + innerExt);
+        });
+      });
+    }
+
+    return result;
+  };
+
+  ast.traverseByType('ruleset', node => {
+    const classNames = fp.compose(
+      fp.map('content'),
+      fp.filter({ type: 'ident' }),
+      fp.flatMap('content'),
+      fp.filter({ type: 'class' }),
+      fp.flatMap('content'),
+      fp.filter({ type: 'selector' })
+    )(node.content);
+
+    if (!classNames.length) return;
+
+    const extensions = getExtensions(node.content);
+    if (!extensions.length) return;
+
+    classNames.forEach(className => {
+      extensions.forEach(ext => {
+        classesMap[className + ext] = false;
+      });
+
+      // Ignore the base class if it only exists for nesting parent selectors
+      const hasDeclarations = fp.compose(
+        fp.filter({ type: 'declaration' }),
+        fp.flatMap('content'),
+        fp.filter({ type: 'block' })
+      )(node.content).length > 0;
+      if (!hasDeclarations) classesMap[className] = true;
+    });
+  });
+
+  return classesMap;
+};
+
 /*
    mutates ast by removing instances of :global
  */

--- a/lib/core/traversalUtils.js
+++ b/lib/core/traversalUtils.js
@@ -97,12 +97,24 @@ export const getParentSelectorClassesMap = (ast: gASTNode): classMapType => {
   // Recursively traverses down the tree looking for parent selector
   // extensions. Recursion is necessary as these selectors can be nested.
   const getExtensions = nodeContent => {
-    const rulesetContent = fp.compose(
-      fp.flatMap('content'),
-      fp.filter({ type: 'ruleset' }),
+    const blockContent = fp.compose(
       fp.flatMap('content'),
       fp.filter({ type: 'block' })
     )(nodeContent);
+
+    const rulesetsContent = fp.flatMap('content', fp.concat(
+      // `ruleset` children
+      fp.filter({ type: 'ruleset' }, blockContent),
+
+      // `ruleset` descendants nested in `include` nodes
+      fp.compose(
+        fp.filter({ type: 'ruleset' }),
+        fp.flatMap('content'),
+        fp.filter({ type: 'block' }),
+        fp.flatMap('content'),
+        fp.filter({ type: 'include' })
+      )(blockContent)
+    ));
 
     const extensions = fp.compose(
       fp.map('content'),
@@ -111,11 +123,11 @@ export const getParentSelectorClassesMap = (ast: gASTNode): classMapType => {
       fp.filter({ type: 'parentSelectorExtension' }),
       fp.flatMap('content'),
       fp.filter({ type: 'selector' })
-    )(rulesetContent);
+    )(rulesetsContent);
 
     if (!extensions.length) return [];
 
-    const innerExtensions = getExtensions(rulesetContent);
+    const innerExtensions = getExtensions(rulesetsContent);
     const result = extensions;
     if (innerExtensions.length) {
       innerExtensions.forEach(innerExt => {

--- a/lib/core/traversalUtils.js
+++ b/lib/core/traversalUtils.js
@@ -127,12 +127,12 @@ export const getParentSelectorClassesMap = (ast: gASTNode): classMapType => {
 
     if (!extensions.length) return [];
 
-    const innerExtensions = getExtensions(rulesetsContent);
+    const nestedExtensions = getExtensions(rulesetsContent);
     const result = extensions;
-    if (innerExtensions.length) {
-      innerExtensions.forEach(innerExt => {
+    if (nestedExtensions.length) {
+      nestedExtensions.forEach(nestedExt => {
         extensions.forEach(ext => {
-          result.push(ext + innerExt);
+          result.push(ext + nestedExt);
         });
       });
     }

--- a/test/files/parentSelector1.scss
+++ b/test/files/parentSelector1.scss
@@ -1,0 +1,7 @@
+.foo {
+  font-weight: 300;
+
+  &_bar {
+    width: 100px;
+  }
+}

--- a/test/files/parentSelector2.scss
+++ b/test/files/parentSelector2.scss
@@ -1,0 +1,9 @@
+.foo {
+  font-weight: 300;
+
+  .bar {
+    &_baz {
+      width: 100px;
+    }
+  }
+}

--- a/test/files/parentSelector3.scss
+++ b/test/files/parentSelector3.scss
@@ -1,0 +1,11 @@
+.foo {
+  font-weight: 300;
+
+  &_baz {
+    width: 100px;
+  }
+
+  &_bar {
+    width: 100px;
+  }
+}

--- a/test/files/parentSelector4.scss
+++ b/test/files/parentSelector4.scss
@@ -1,0 +1,7 @@
+.foo {
+  font-weight: 300;
+
+  &_baz, &_bar {
+    width: 100px;
+  }
+}

--- a/test/files/parentSelector5.scss
+++ b/test/files/parentSelector5.scss
@@ -1,0 +1,7 @@
+.foo, .bar {
+  font-weight: 300;
+
+  &_baz {
+    font-weight: 300;
+  }
+}

--- a/test/files/parentSelector6.scss
+++ b/test/files/parentSelector6.scss
@@ -1,0 +1,11 @@
+.foo {
+  font-weight: 300;
+
+  &_bar {
+    font-weight: 300;
+
+    &_baz {
+      font-weight: 300;
+    }
+  }
+}

--- a/test/files/parentSelector7.scss
+++ b/test/files/parentSelector7.scss
@@ -1,0 +1,9 @@
+.foo {
+  &_bar {
+    font-weight: 300;
+  }
+
+  &_baz {
+    font-weight: 300;
+  }
+}

--- a/test/files/parentSelector8.scss
+++ b/test/files/parentSelector8.scss
@@ -1,0 +1,9 @@
+@import "~styles/media-queries";
+
+.foo {
+  @include match-medium {
+    &_bar {
+      font-weight: 300;
+    }
+  };
+}

--- a/test/lib/rules/no-undef-class.js
+++ b/test/lib/rules/no-undef-class.js
@@ -186,6 +186,17 @@ ruleTester.run('no-undef-class', rule, {
         );
       `,
     }),
+    test({
+      code: `
+        import s from './parentSelector8.scss';
+
+        export default Foo = () => (
+          <div className={s.foo}>
+            <div className={s.foo_bar}></div>
+          </div>
+        );
+      `,
+    }),
     /*
        file that can't be parsed should not give any error
      */

--- a/test/lib/rules/no-undef-class.js
+++ b/test/lib/rules/no-undef-class.js
@@ -113,6 +113,80 @@ ruleTester.run('no-undef-class', rule, {
       `,
     }),
     /*
+       using parent selector (`&`)
+     */
+    test({
+      code: `
+        import s from './parentSelector1.scss';
+
+        export default Foo = () => (
+          <div className={s.foo}>
+            <div className={s.foo_bar}></div>
+          </div>
+        );
+      `,
+    }),
+    test({
+      code: `
+        import s from './parentSelector2.scss';
+
+        export default Foo = () => (
+          <div className={s.foo}>
+            <div className={s.bar}></div>
+            <div className={s.bar_baz}></div>
+          </div>
+        );
+      `,
+    }),
+    test({
+      code: `
+        import s from './parentSelector3.scss';
+
+        export default Foo = () => (
+          <div className={s.foo}>
+            <div className={s.foo_bar}></div>
+            <div className={s.foo_baz}></div>
+          </div>
+        );
+      `,
+    }),
+    test({
+      code: `
+        import s from './parentSelector4.scss';
+
+        export default Foo = () => (
+          <div className={s.foo}>
+            <div className={s.foo_bar}></div>
+            <div className={s.foo_baz}></div>
+          </div>
+        );
+      `,
+    }),
+    test({
+      code: `
+        import s from './parentSelector5.scss';
+
+        export default Foo = () => (
+          <div className={s.foo}>
+            <div className={s.foo_baz}></div>
+            <div className={s.bar_baz}></div>
+          </div>
+        );
+      `,
+    }),
+    test({
+      code: `
+        import s from './parentSelector6.scss';
+
+        export default Foo = () => (
+          <div className={s.foo}>
+            <div className={s.foo_bar}></div>
+            <div className={s.foo_bar_baz}></div>
+          </div>
+        );
+      `,
+    }),
+    /*
        file that can't be parsed should not give any error
      */
     test({

--- a/test/lib/rules/no-unused-class.js
+++ b/test/lib/rules/no-unused-class.js
@@ -84,6 +84,22 @@ ruleTester.run('no-unused-class', rule, {
         );
       `,
     }),
+    /*
+       check if classes are ignored if they only
+       exist for nesting parent selectors (`&`)
+     */
+    test({
+      code: `
+        import s from './parentSelector7.scss';
+
+        export default Foo = () => (
+          <div>
+            <span className={s.foo_bar}></span>
+            <span className={s.foo_baz}></span>
+          </div>
+        );
+      `,
+    }),
   ],
   /*
      invalid cases


### PR DESCRIPTION
This fixes the first issue described in #15 .

Was great fun to implement this, using functional programming techniques for traversing ASTs is a great fit 👍 .