### PR TITLE
Add camelCase option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,17 @@ This plugin intends to help you in tracking down problems when you are using css
 where container is the css class that you want to mark as used.
 Add all such classes in the array.
 
+>If you use the `camelCase` option of `css-loader`, you must also enabled it for this plugin
+```js
+/* eslint css-modules/no-unused-class: [2, { camelCase: true }] */
+```
+
 * `css-modules/no-undef-class`: You must not use a non existing class.
+
+>If you use the `camelCase` option of `css-loader`, you must also enabled it for this plugin
+```js
+/* eslint css-modules/no-undef-class: [2, { camelCase: true }] */
+```
 
 ## Installation
 
@@ -33,6 +43,23 @@ npm i --save-dev eslint-plugin-css-modules
   ],
   "extends": [
     "plugin:css-modules/recommended"
+  ]
+}
+```
+
+You may also tweak the rules individually. For instance, if you use the [camelCase](https://github.com/webpack-contrib/css-loader) option of webpack's css-loader:
+
+```json
+{
+  "plugins": [
+    "css-modules"
+  ],
+  "extends": [
+    "plugin:css-modules/recommended"
+  ],
+  "rules": [
+    "css-modules/no-unused-class": [2, { "camelCase": true }],
+    "css-modules/no-undef-class": [2, { "camelCase": true }]
   ]
 }
 ```

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -3,6 +3,7 @@
 import fs from 'fs';
 import path from 'path';
 import fp from 'lodash/fp';
+import _ from 'lodash';
 import gonzales from './gonzales';
 
 import type { JsNode } from '../types';
@@ -17,17 +18,32 @@ import {
 
 const styleExtensionRegex = /\.(s?css|less)$/;
 
-export const getPropertyName = (node: JsNode): ?string => {
-  if (node.computed) {
+export const getPropertyName = (node: JsNode, camelCase): ?string => {
+  const propertyName = node.computed
     /*
        square braces eg s['header']
        we won't use node.property.name because it is for cases like
        s[abc] where abc is a variable
      */
-    return node.property.value;
+     ? node.property.value
+     /* dot notation, eg s.header */
+     : node.property.name;
+
+  /*
+     skip property names starting with _
+     eg. special functions provided
+     by css modules like _getCss()
+
+     Tried to just skip function calls, but the parser
+     thinks of normal property access like s._getCss and
+     function calls like s._getCss() as same.
+   */
+  if (!propertyName || _.startsWith(propertyName, '_')) {
+    return null;
   }
 
-  return node.property.name;  /* dot notation, eg s.header */
+  /* Convert to hyphenated if camelCase was used */
+  return camelCase ? _.kebabCase(propertyName) : propertyName;
 };
 
 export const getStyleImportNodeData = (node: JsNode): ?Object => {

--- a/lib/rules/no-undef-class.js
+++ b/lib/rules/no-undef-class.js
@@ -15,10 +15,19 @@ export default {
     docs: {
       description: 'Checks that you are using the existent css/scss/less classes',
       recommended: true,
-    }
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          camelCase: { type: 'boolean' },
+        },
+      }
+    ],
   },
   create (context: Object) {
     const dirName = path.dirname(context.getFilename());
+    const camelCase = _.get(context, 'options[0].camelCase');
 
     /*
        maps variable name to property Object
@@ -69,18 +78,9 @@ export default {
 
         const objectName = node.object.name;
 
-        const propertyName = getPropertyName(node);
+        const propertyName = getPropertyName(node, camelCase);
 
-        if (!propertyName || _.startsWith(propertyName, '_')) {
-          /*
-             skip property names starting with _
-             eg. special functions provided
-             by css modules like _getCss()
-
-             Tried to just skip function calls, but the parser
-             thinks of normal property access like s._getCss and
-             function calls like s._getCss() as same.
-           */
+        if (!propertyName) {
           return;
         }
 

--- a/lib/rules/no-unused-class.js
+++ b/lib/rules/no-unused-class.js
@@ -16,10 +16,21 @@ export default {
     docs: {
       description: 'Checks that you are using all css/scss/less classes',
       recommended: true,
-    }
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          camelCase: { type: 'boolean' },
+          markAsUsed: { type: 'boolean' },
+        },
+      }
+    ],
   },
   create (context: Object) {
     const dirName = path.dirname(context.getFilename());
+    const markAsUsed = _.get(context, 'options[0].markAsUsed');
+    const camelCase = _.get(context, 'options[0].camelCase');
 
     /*
        maps variable name to property Object
@@ -69,19 +80,9 @@ export default {
          */
 
         const objectName = node.object.name;
+        const propertyName = getPropertyName(node, camelCase);
 
-        const propertyName = getPropertyName(node);
-
-        if (!propertyName || _.startsWith(propertyName, '_')) {
-          /*
-             skip property names starting with _
-             eg. special functions provided
-             by css modules like _getCss()
-
-             Tried to just skip function calls, but the parser
-             thinks of normal property access like s._getCss and
-             function calls like s._getCss() as same.
-           */
+        if (!propertyName) {
           return;
         }
 
@@ -98,13 +99,6 @@ export default {
          */
 
         /*
-           if option is passed to mark a class as used, example:
-           eslint css-modules/no-unused-class: [2, { markAsUsed: ['container'] }]
-           note: options[0] is actually the element at index 1 in above line
-         */
-        const markAsUsed = _.get(context, 'options[0].markAsUsed');
-
-        /*
            we are looping over each import style node in program
            example:
            ```
@@ -116,6 +110,10 @@ export default {
         _.forOwn(map, (o) => {
           const { classes, node } = o;
 
+          /*
+             if option is passed to mark a class as used, example:
+             eslint css-modules/no-unused-class: [2, { markAsUsed: ['container'] }]
+           */
           _.forEach(markAsUsed, usedClass => {
             classes[usedClass] = true;
           });

--- a/test/files/noUndefClass3.scss
+++ b/test/files/noUndefClass3.scss
@@ -1,0 +1,7 @@
+.foo-bar {
+  min-width: 1024px;
+}
+
+.bar-foo {
+    min-width: 1024px;
+}

--- a/test/files/noUnusedClass3.scss
+++ b/test/files/noUnusedClass3.scss
@@ -1,0 +1,7 @@
+.foo-bar {
+  display: flex;
+}
+
+:global(.bar) {
+  font-weight: bold;
+}

--- a/test/lib/rules/no-undef-class.js
+++ b/test/lib/rules/no-undef-class.js
@@ -240,6 +240,51 @@ ruleTester.run('no-undef-class', rule, {
         );
       `
     }),
+    /*
+       check if camel case classes work as expected
+     */
+    test({
+      code: `
+        import s from './noUndefClass3.scss';
+
+        export default Foo = () => (
+          <div className={s.fooBar}>
+            <div className={s.barFoo}>
+            </div>
+          </div>
+        );
+      `,
+      options: [{ camelCase: true }],
+    }),
+    /*
+       check if camel case classes work as expected
+     */
+    test({
+      code: `
+        import s from './noUndefClass3.scss';
+
+        export default Foo = () => (
+          <div className={s['foo-bar']}>
+            <div className={s['bar-foo']}>
+            </div>
+          </div>
+        );
+      `,
+      options: [{ camelCase: true }],
+    }),
+    test({
+      code: `
+        import s from './noUndefClass3.scss';
+
+        export default Foo = () => (
+          <div className={s.fooBar}>
+            <div className={s.barFoo}>
+            </div>
+          </div>
+        );
+      `,
+      options: [{ camelCase: true }],
+    }),
   ],
   /*
      invalid cases
@@ -398,6 +443,25 @@ ruleTester.run('no-undef-class', rule, {
       `,
       errors: [
         'Class \'bar\' not found',
+        'Class \'baz\' not found',
+      ],
+    }),
+    /*
+       should detect if camel case properties are NOT defined
+     */
+    test({
+      code: `
+        import s from './noUndefClass3.scss';
+
+        export default Foo = () => (
+          <div className={s.fooBar}>
+            <div className={s.baz}>
+            </div>
+          </div>
+        );
+      `,
+      options: [{ camelCase: true }],
+      errors: [
         'Class \'baz\' not found',
       ],
     }),

--- a/test/lib/rules/no-unused-class.js
+++ b/test/lib/rules/no-unused-class.js
@@ -100,6 +100,35 @@ ruleTester.run('no-unused-class', rule, {
         );
       `,
     }),
+    /*
+       check if camel case classes work as expected
+     */
+    test({
+      code: `
+        import s from './noUnusedClass3.scss';
+
+        export default Foo = () => (
+          <div className={s.fooBar}>
+            <div className={s.bar}>
+            </div>
+          </div>
+        );
+      `,
+      options: [{ camelCase: true }],
+    }),
+    test({
+      code: `
+        import s from './noUnusedClass3.scss';
+
+        export default Foo = () => (
+          <div className={s['foo-bar']}>
+            <div className={s.bar}>
+            </div>
+          </div>
+        );
+      `,
+      options: [{ camelCase: true }],
+    }),
   ],
   /*
      invalid cases
@@ -217,6 +246,25 @@ ruleTester.run('no-unused-class', rule, {
       `,
       errors: [
         'Unused classes found: foo_bar',
+      ],
+    }),
+    /*
+       should detect if camel case properties are NOT used
+     */
+    test({
+      code: `
+        import s from './noUnusedClass3.scss';
+
+        export default Foo = () => (
+          <div>
+            <div className={s.bar}>
+            </div>
+          </div>
+        );
+      `,
+      options: [{ camelCase: true }],
+      errors: [
+        'Unused classes found: foo-bar',
       ],
     }),
   ],


### PR DESCRIPTION
Fixes #6 

- Refactor code so that `getPropertyName` handles not only properties that start with `_` but also the `camelCase` option
- Add tests for the feature
- Add schema to rules
- Update README