### PR TITLE
Add support for absolute paths and `settings.basePath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ The camelCase option has 4 possible values, see [css-loader#camelCase](https://g
 true | "dashes" | "only" | "dashes-only"
 ```
 
+## Specifying base path
+
+You can specify path for the base directory via plugin settings in .eslintrc. This is used by the plugin to resolve absolute (S)CSS paths:
+
+```json
+{
+  "settings": {
+    "css-modules": {
+      "basePath": "app/scripts/..."
+    }
+  }
+}
+```
+
 ## Screen Shot
 
 ![ScreenShot](https://raw.githubusercontent.com/atfzl/eslint-plugin-css-modules/master/screenshots/screenshot3.png)

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -24,6 +24,17 @@ function dashesCamelCase (str: string) {
   });
 }
 
+export const getFilePath = (context, styleFilePath) => {
+  const settings = context.settings['css-modules'];
+
+  const dirName = path.dirname(context.getFilename());
+  const basePath = (settings && settings.basePath) ? settings.basePath : '';
+
+  return styleFilePath.startsWith('.')
+    ? path.resolve(dirName, styleFilePath)
+    : path.resolve(basePath, styleFilePath);
+};
+
 export const getPropertyName = (node: JsNode): ?string => {
   const propertyName = node.computed
     /*

--- a/lib/rules/no-undef-class.js
+++ b/lib/rules/no-undef-class.js
@@ -1,5 +1,4 @@
 /* @flow */
-import path from 'path';
 import _ from 'lodash';
 
 import {
@@ -7,6 +6,7 @@ import {
   getStyleClasses,
   getPropertyName,
   getClassesMap,
+  getFilePath,
 } from '../core';
 
 import type { JsNode } from '../types';
@@ -27,7 +27,6 @@ export default {
     ],
   },
   create (context: Object) {
-    const dirName = path.dirname(context.getFilename());
     const camelCase = _.get(context, 'options[0].camelCase');
 
     /*
@@ -63,7 +62,8 @@ export default {
           importNode,
         } = styleImportNodeData;
 
-        const styleFileAbsolutePath = path.resolve(dirName, styleFilePath);
+        const styleFileAbsolutePath = getFilePath(context, styleFilePath);
+
         const classes = getStyleClasses(styleFileAbsolutePath);
         const classesMap = classes && getClassesMap(classes, camelCase);
 

--- a/lib/rules/no-unused-class.js
+++ b/lib/rules/no-unused-class.js
@@ -1,5 +1,4 @@
 /* @flow */
-import path from 'path';
 import fp from 'lodash/fp';
 import _ from 'lodash';
 
@@ -8,6 +7,7 @@ import {
   getStyleClasses,
   getPropertyName,
   getClassesMap,
+  getFilePath,
 } from '../core';
 
 import type { JsNode } from '../types';
@@ -29,7 +29,6 @@ export default {
     ],
   },
   create (context: Object) {
-    const dirName = path.dirname(context.getFilename());
     const markAsUsed = _.get(context, 'options[0].markAsUsed');
     const camelCase = _.get(context, 'options[0].camelCase');
 
@@ -68,7 +67,7 @@ export default {
           importNode,
         } = styleImportNodeData;
 
-        const styleFileAbsolutePath = path.resolve(dirName, styleFilePath);
+        const styleFileAbsolutePath = getFilePath(context, styleFilePath);
 
         // this will be used to mark s.foo as used in MemberExpression
         const classes = getStyleClasses(styleFileAbsolutePath);

--- a/test/lib/rules/no-undef-class.js
+++ b/test/lib/rules/no-undef-class.js
@@ -12,6 +12,19 @@ ruleTester.run('no-undef-class', rule, {
    */
   valid: [
     /*
+      absolute import
+      eg: 'foo/bar.scss'
+    */
+    test({
+      code: `
+        import s from 'test/files/noUndefClass1.scss';
+
+        export default Foo = () => (
+          <div className={s.container}></div>
+        );
+      `,
+    }),
+    /*
        dot notation
        eg: s.container
      */

--- a/test/lib/rules/no-unused-class.js
+++ b/test/lib/rules/no-unused-class.js
@@ -12,6 +12,19 @@ ruleTester.run('no-unused-class', rule, {
    */
   valid: [
     /*
+      absolute import
+      eg: 'foo/bar.scss'
+    */
+    test({
+      code: `
+        import s from 'test/files/noUndefClass1.scss';
+
+        export default Foo = () => (
+          <div className={s.container}></div>
+        );
+      `,
+    }),
+    /*
        dot notation and square brackets
        eg: s.foo and s['bar']
      */


### PR DESCRIPTION
Adds support for resolving absolute imports as well as being able to configure base dir via basePath:

```js
// in .eslintrc
...
settings: {
  'css-modules': {
    basePath: 'app/scripts/...'
  }
}
```