### PR TITLE
Add support for :export keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add all such classes in the array.
 /* eslint css-modules/no-unused-class: [2, { camelCase: true }] */
 ```
 
-* `css-modules/no-undef-class`: You must not use a non existing class.
+* `css-modules/no-undef-class`: You must not use a non existing class, or a property that hasn't been exported using the [:export keyword](https://github.com/css-modules/icss#export).
 
 >If you use the `camelCase` option of `css-loader`, you must also enabled it for this plugin
 ```js

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -6,13 +6,14 @@ import fp from 'lodash/fp';
 import _ from 'lodash';
 import gonzales from './gonzales';
 
-import type { JsNode } from '../types';
+import type { JsNode, gASTNode } from '../types';
 
 import {
   getRegularClassesMap,
   getComposesClassesMap,
   getExtendClassesMap,
   getParentSelectorClassesMap,
+  getICSSExportPropsMap,
   eliminateGlobals,
 } from './traversalUtils';
 
@@ -118,14 +119,17 @@ export const getStyleImportNodeData = (node: JsNode): ?Object => {
   }
 };
 
-export const getStyleClasses = (filePath: string): ?Object => {
+export const fileExists = (filePath: string): boolean => {
   try {
     // check if file exists
     fs.statSync(filePath);
+    return true;
   } catch (e) {
-    return {}; // user will get error like class 'x' not found
+    return false;
   }
+};
 
+export const getAST = (filePath: string): gASTNode | null => {
   const fileContent = fs.readFileSync(filePath);
 
   const syntax = path.extname(filePath).slice(1); // remove leading .
@@ -137,6 +141,10 @@ export const getStyleClasses = (filePath: string): ?Object => {
     return null;
   }
 
+  return ast;
+};
+
+export const getStyleClasses = (ast: gASTNode): ?Object => {
   /*
      mutates ast by removing :global scopes
    */
@@ -152,5 +160,12 @@ export const getStyleClasses = (filePath: string): ?Object => {
     ...composedClassesMap,
     ...extendClassesMap,
     ...parentSelectorClassesMap
+  };
+};
+
+export const getExportPropsMap = (ast: gASTNode): ?Object => {
+  const exportPropsMap = getICSSExportPropsMap(ast);
+  return {
+    ...exportPropsMap
   };
 };

--- a/lib/core/traversalUtils.js
+++ b/lib/core/traversalUtils.js
@@ -8,6 +8,37 @@ type classMapType = {
   [key: string]: boolean,
 }
 
+export const getICSSExportPropsMap = (ast: gASTNode): classMapType => {
+  const ruleSets: Array<gASTNode> = [];
+  ast.traverseByType('ruleset', node => ruleSets.push(node));
+
+  return fp.compose(
+    fp.reduce((result, key) => {
+      const prop = fp.compose(fp.nth(0), fp.map('content'))(key);
+      result[prop] = prop; // e.g. { myProp: 'myProp' }
+      return result;
+    }, {}),
+    fp.map('content'),
+    fp.filter({ type: 'property' }),
+    fp.flatMap('content'),
+    fp.filter({ type: 'declaration' }),
+    fp.flatMap('content'),
+    fp.filter({ type: 'block' }),
+    fp.flatMap('content'),
+    fp.filter({
+      content: [{
+        type: 'selector',
+        content: [{
+          type: 'pseudoClass',
+          content: [{
+            type: 'ident', content: 'export'
+          }]
+        }]
+      }]
+    })
+  )(ruleSets);
+};
+
 export const getRegularClassesMap = (ast: gASTNode): classMapType => {
   const ruleSets: Array<gASTNode> = [];
   ast.traverseByType('ruleset', node => ruleSets.push(node));

--- a/lib/rules/no-undef-class.js
+++ b/lib/rules/no-undef-class.js
@@ -3,9 +3,12 @@ import _ from 'lodash';
 
 import {
   getStyleImportNodeData,
+  getAST,
+  fileExists,
   getStyleClasses,
   getPropertyName,
   getClassesMap,
+  getExportPropsMap,
   getFilePath,
 } from '../core';
 
@@ -63,12 +66,22 @@ export default {
         } = styleImportNodeData;
 
         const styleFileAbsolutePath = getFilePath(context, styleFilePath);
+        let classesMap = {};
+        let exportPropsMap = {};
 
-        const classes = getStyleClasses(styleFileAbsolutePath);
-        const classesMap = classes && getClassesMap(classes, camelCase);
+        if (fileExists(styleFileAbsolutePath)) {
+          const ast = getAST(styleFileAbsolutePath);
+          const classes = ast && getStyleClasses(ast);
+
+          classesMap = classes && getClassesMap(classes, camelCase);
+          exportPropsMap = ast && getExportPropsMap(ast);
+        }
 
         // this will be used to check if classes are defined
         _.set(map, `${importName}.classesMap`, classesMap);
+
+        // this will be used to check if :export properties are defined
+        _.set(map, `${importName}.exportPropsMap`, exportPropsMap);
 
         // save node for reporting unused styles
         _.set(map, `${importName}.node`, importNode);
@@ -87,9 +100,11 @@ export default {
         }
 
         const classesMap = _.get(map, `${objectName}.classesMap`);
+        const exportPropsMap = _.get(map, `${objectName}.exportPropsMap`);
 
-        if (classesMap && classesMap[propertyName] == null) {
-          context.report(node.property, `Class '${propertyName}' not found`);
+        if (classesMap && classesMap[propertyName] == null &&
+            exportPropsMap && exportPropsMap[propertyName] == null) {
+          context.report(node.property, `Class or exported property '${propertyName}' not found`);
         }
       }
     };

--- a/lib/rules/no-unused-class.js
+++ b/lib/rules/no-unused-class.js
@@ -9,6 +9,8 @@ import {
   getPropertyName,
   getClassesMap,
   getFilePath,
+  getAST,
+  fileExists,
 } from '../core';
 
 import type { JsNode } from '../types';
@@ -70,9 +72,15 @@ export default {
 
         const styleFileAbsolutePath = getFilePath(context, styleFilePath);
 
-        // this will be used to mark s.foo as used in MemberExpression
-        const classes = getStyleClasses(styleFileAbsolutePath);
-        const classesMap = classes && getClassesMap(classes, camelCase);
+        let classes = {};
+        let classesMap = {};
+
+        if (fileExists(styleFileAbsolutePath)) {
+          // this will be used to mark s.foo as used in MemberExpression
+          const ast = getAST(styleFileAbsolutePath);
+          classes = ast && getStyleClasses(ast);
+          classesMap = classes && getClassesMap(classes, camelCase);
+        }
 
         _.set(map, `${importName}.classes`, classes);
         _.set(map, `${importName}.classesMap`, classesMap);

--- a/test/files/export1.scss
+++ b/test/files/export1.scss
@@ -1,0 +1,7 @@
+.bar {
+  color: blue;
+}
+
+:export {
+  myProp: something;
+}

--- a/test/files/export2.scss
+++ b/test/files/export2.scss
@@ -1,0 +1,7 @@
+.bar {
+  color: blue;
+}
+
+:export {
+  otherProp: something;
+}

--- a/test/lib/rules/no-undef-class.js
+++ b/test/lib/rules/no-undef-class.js
@@ -235,6 +235,22 @@ ruleTester.run('no-undef-class', rule, {
       `
     }),
     /*
+       ICSS :export pseudo-selector with a correct prop name should not give error
+       https://github.com/css-modules/icss#export
+     */
+    test({
+      code: `
+        import s from './export1.scss';
+
+        export default Foo = () => (
+          <div className={s.bar}>
+            <div className={s.myProp}>
+            </div>
+          </div>
+        );
+      `
+    }),
+    /*
        use gonzales-primitive when gonzales fails to parse
      */
     test({
@@ -359,7 +375,7 @@ ruleTester.run('no-undef-class', rule, {
         );
       `,
       errors: [
-        'Class \'containr\' not found'
+        'Class or exported property \'containr\' not found'
       ]
     }),
     /*
@@ -374,7 +390,7 @@ ruleTester.run('no-undef-class', rule, {
         );
       `,
       errors: [
-        'Class \'containr\' not found',
+        'Class or exported property \'containr\' not found',
       ],
     }),
     /*
@@ -390,7 +406,26 @@ ruleTester.run('no-undef-class', rule, {
         );
       `,
       errors: [
-        'Class \'bold\' not found',
+        'Class or exported property \'bold\' not found',
+      ],
+    }),
+    /*
+       ICSS :export pseudo-selector with wrong prop name
+       https://github.com/css-modules/icss#export
+     */
+    test({
+      code: `
+        import s from './export2.scss';
+
+        export default Foo = () => (
+          <div className={s.bar}>
+            <div className={s.myProp}>
+            </div>
+          </div>
+        );
+      `,
+      errors: [
+        'Class or exported property \'myProp\' not found',
       ],
     }),
     /*
@@ -405,7 +440,7 @@ ruleTester.run('no-undef-class', rule, {
         );
       `,
       errors: [
-        'Class \'bold\' not found',
+        'Class or exported property \'bold\' not found',
       ],
     }),
     /*
@@ -422,7 +457,7 @@ ruleTester.run('no-undef-class', rule, {
         );
       `,
       errors: [
-        'Class \'bazz\' not found',
+        'Class or exported property \'bazz\' not found',
       ],
     }),
     /*
@@ -440,7 +475,7 @@ ruleTester.run('no-undef-class', rule, {
         );
       `,
       errors: [
-        'Class \'bazz\' not found',
+        'Class or exported property \'bazz\' not found',
       ],
     }),
     /*
@@ -457,7 +492,7 @@ ruleTester.run('no-undef-class', rule, {
         );
       `,
       errors: [
-        'Class \'bazz\' not found',
+        'Class or exported property \'bazz\' not found',
       ],
     }),
     /*
@@ -475,7 +510,7 @@ ruleTester.run('no-undef-class', rule, {
         );
       `,
       errors: [
-        'Class \'foo_baz\' not found',
+        'Class or exported property \'foo_baz\' not found',
       ],
     }),
     /*
@@ -492,8 +527,8 @@ ruleTester.run('no-undef-class', rule, {
         );
       `,
       errors: [
-        'Class \'bar\' not found',
-        'Class \'baz\' not found',
+        'Class or exported property \'bar\' not found',
+        'Class or exported property \'baz\' not found',
       ],
     }),
     /*
@@ -513,7 +548,7 @@ ruleTester.run('no-undef-class', rule, {
       `,
       options: [{ camelCase: true }],
       errors: [
-        'Class \'fooBaz\' not found',
+        'Class or exported property \'fooBaz\' not found',
       ],
     }),
     test({
@@ -530,7 +565,7 @@ ruleTester.run('no-undef-class', rule, {
       `,
       options: [{ camelCase: true }],
       errors: [
-        'Class \'foo-baz\' not found',
+        'Class or exported property \'foo-baz\' not found',
       ],
     }),
     /*
@@ -556,10 +591,10 @@ ruleTester.run('no-undef-class', rule, {
       `,
       options: [{ camelCase: 'dashes' }],
       errors: [
-        'Class \'snakeCased\' not found',
-        'Class \'fooBaz\' not found',
-        'Class \'already-camel-cased\' not found',
-        'Class \'foo-baz\' not found',
+        'Class or exported property \'snakeCased\' not found',
+        'Class or exported property \'fooBaz\' not found',
+        'Class or exported property \'already-camel-cased\' not found',
+        'Class or exported property \'foo-baz\' not found',
       ],
     }),
     /*
@@ -585,11 +620,11 @@ ruleTester.run('no-undef-class', rule, {
       `,
       options: [{ camelCase: 'only' }],
       errors: [
-        'Class \'fooBaz\' not found',
-        'Class \'foo-bar\' not found',
-        'Class \'already-camel-cased\' not found',
-        'Class \'snake_cased\' not found',
-        'Class \'foo-baz\' not found',
+        'Class or exported property \'fooBaz\' not found',
+        'Class or exported property \'foo-bar\' not found',
+        'Class or exported property \'already-camel-cased\' not found',
+        'Class or exported property \'snake_cased\' not found',
+        'Class or exported property \'foo-baz\' not found',
       ],
     }),
     /*
@@ -615,11 +650,11 @@ ruleTester.run('no-undef-class', rule, {
       `,
       options: [{ camelCase: 'dashes-only' }],
       errors: [
-        'Class \'snakeCased\' not found',
-        'Class \'fooBaz\' not found',
-        'Class \'foo-bar\' not found',
-        'Class \'already-camel-cased\' not found',
-        'Class \'foo-baz\' not found',
+        'Class or exported property \'snakeCased\' not found',
+        'Class or exported property \'fooBaz\' not found',
+        'Class or exported property \'foo-bar\' not found',
+        'Class or exported property \'already-camel-cased\' not found',
+        'Class or exported property \'foo-baz\' not found',
       ],
     }),
   ],

--- a/test/lib/rules/no-unused-class.js
+++ b/test/lib/rules/no-unused-class.js
@@ -56,6 +56,19 @@ ruleTester.run('no-unused-class', rule, {
       `,
     }),
     /*
+       ignore props exported by ICSS :export pseudo-selector
+       https://github.com/css-modules/icss#export
+     */
+    test({
+      code: `
+        import s from './export1.scss';
+
+        export default Foo = () => (
+          <div className={s.bar}></div>
+        );
+      `,
+    }),
+    /*
        check if composes classes are ignored
      */
     test({


### PR DESCRIPTION
## What is Interoperable CSS (ICSS)?

[ICSS](https://github.com/css-modules/icss) is part of CSS modules and a superset of standard CSS, making use of two additional pseudo-selectors: `:import` and `:export`.

The feature is related to this Pull Request is the `:export` selector.

All the popular CSS preprocessors support outputting the `:export` block, and it is also supported by Webpack.

 ts most typical use case is to pass variables from CSS to Javascript. 

Here's an example:

`variables.scss`
```
$black-color: #414042;

:export {
  blackcolor: $black-color;
}
```

```js
import variables from 'variables.scss';

const CSS = {
  backgroudColor: variables.blackcolor
}

export default ({}) => {
  return <div style={CSS}>Content</div>
}
```
full example here: https://til.hashrocket.com/posts/sxbrscjuqu-share-scss-variables-with-javascript

## What is the problem when using eslint-plugin-css-modules?

When using the `:export` feature together with `no-undef-class` rule, there are linting errors because the exported properties are referenced the same way in Javascript as regular CSS classes.

The  `no-undef-class` rule does not know about the exported properties so it gives an error. 

This also means that the example that I posted above would give an error.

## The proposed solution

**no-undef-class** - Parse properties from the `:export` keyword and only warn if the referenced name in Javascript is missing both the class and the exported property in CSS. Modifying this rule is the only way to go, because creating a new rule would not help as the as the `no-undef-class` would still warn for a class missing when `:export` is used.

**no-unused-class** - Don't warn for `:export` properties at all. This is because in many cases `:export` is used to share colors or other settings between the application, so a component might not use all of the exported properties.

The change to `no-undef-class` should not change the current usage at all, only add support for `:export`. 

In order to keep `no-undef-class` and `no-unused-class` separated and to avoid generating the AST multiple times, I refactored the code so that check if file exists, generating the AST and getting classnames are now in separate functions.

I also changed the error message for `no-undef-class` to tell that an exported property might be used.

**Changes**

* Add getICSSExportPropsMap that will get properties from an :export block.
* Refactor checking if file exists, getting AST and getting classes to separate methods to avoid having to generating the AST multiple times.
* Change `no-undef-class` rule to also check if the used class is an :export property.

@atfzl