### PR TITLE
Support no-undef-class with :global()

### DIFF
--- a/lib/core/traversalUtils.js
+++ b/lib/core/traversalUtils.js
@@ -206,6 +206,7 @@ export const getParentSelectorClassesMap = (ast: gASTNode): classMapType => {
 
 /*
    mutates ast by removing instances of :global
+   If global psuedoClass and class are present only remove psuedoclass.
  */
 export const eliminateGlobals = (ast: gASTNode) => {
   ast.traverse((node, index, parent) => {
@@ -221,7 +222,33 @@ export const eliminateGlobals = (ast: gASTNode) => {
           fp.get('content'),
         )(node)
       ) {
-        parent.removeChild(index);
+        const selectorNodes = fp.compose(
+          fp.filter({ type: 'selector' }),
+          fp.get('content'),
+        )(node);
+
+        selectorNodes.forEach(selectorNode => {
+          if (fp.compose(
+            fp.negate(fp.isEmpty),
+            fp.find({ type: 'arguments' }),
+            fp.get('content'),
+            fp.find({ type: 'pseudoClass' }),
+            fp.get('content'),
+          )(selectorNode) &&
+          fp.compose(
+            fp.negate(fp.isEmpty),
+            fp.find({ type: 'class' }),
+            fp.get('content'),
+          )(selectorNode)) {
+            selectorNode.traverse((subNode, subNodeIndex, subNodeParent) => {
+              if (subNode.type === 'pseudoClass') {
+                subNodeParent.removeChild(subNodeIndex);
+              }
+            });
+          } else {
+            parent.removeChild(index);
+          }
+        });
       }
     }
   });

--- a/test/lib/core/traversalUtils.test.js
+++ b/test/lib/core/traversalUtils.test.js
@@ -176,5 +176,26 @@ describe('eliminateGlobals()', () => {
 .someother  {}`
     );
   });
+
+  it('should remove only classes wrapped in :global() - global middle', () => {
+    const content = `
+.bar {}
+
+.someother :global(.bar.foo) .somethingelse {}`;
+
+    const ast = gonzales.parse(
+      content,
+      { syntax: 'scss' }
+    );
+
+    eliminateGlobals(ast);
+
+    expect(ast.toString()).to.be.equal(
+      `
+.bar {}
+
+.someother  .somethingelse {}`
+    );
+  });
 });
 

--- a/test/lib/core/traversalUtils.test.js
+++ b/test/lib/core/traversalUtils.test.js
@@ -116,7 +116,7 @@ describe('eliminateGlobals()', () => {
 
   it('should remove classes wrapped in :global()', () => {
     const content = `
-.bar {}
+ .bar {}
 
 :global(.bar.foo) {}`;
 
@@ -129,9 +129,52 @@ describe('eliminateGlobals()', () => {
 
     expect(ast.toString()).to.be.equal(
       `
-.bar {}
+ .bar {}
 
 `
     );
   });
+
+  it('should remove only classes wrapped in :global() - global first', () => {
+    const content = `
+.bar {}
+
+:global(.bar.foo) .someother {}`;
+
+    const ast = gonzales.parse(
+      content,
+      { syntax: 'scss' }
+    );
+
+    eliminateGlobals(ast);
+
+    expect(ast.toString()).to.be.equal(
+      `
+.bar {}
+
+ .someother {}`
+    );
+  });
+
+  it('should remove only classes wrapped in :global() - global second', () => {
+    const content = `
+.bar {}
+
+.someother :global(.bar.foo) {}`;
+
+    const ast = gonzales.parse(
+      content,
+      { syntax: 'scss' }
+    );
+
+    eliminateGlobals(ast);
+
+    expect(ast.toString()).to.be.equal(
+      `
+.bar {}
+
+.someother  {}`
+    );
+  });
 });
+


### PR DESCRIPTION
Proposed solution to issue https://github.com/atfzl/eslint-plugin-css-modules/issues/14

- If the node that contains `:global` pseudoClass contains arguments and other classes, only remove the pseudoClass.
- If the node does not contain other classes remove the full node.