### PR TITLE
Include the plugin in the recommended config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ export rules from './rules';
 
 export const configs = {
   recommended: {
+    plugins: ['css-modules'],
     rules: {
       'css-modules/no-unused-class': 2, // error
       'css-modules/no-undef-class': 2,  // error


### PR DESCRIPTION
Every other eslint plugin does this automatically when extending the recommended config.