### PR TITLE
Include classes in :not()

### DIFF
--- a/lib/core/traversalUtils.js
+++ b/lib/core/traversalUtils.js
@@ -41,7 +41,7 @@ export const getICSSExportPropsMap = (ast: gASTNode): classMapType => {
 
 export const getRegularClassesMap = (ast: gASTNode): classMapType => {
   const ruleSets: Array<gASTNode> = [];
-  ast.traverseByTypes(['class'], node => ruleSets.push(node));
+  ast.traverseByTypes('class', node => ruleSets.push(node));
   return fp.compose(
     fp.reduce((result, key) => {
       result[key] = false; // classes haven't been used

--- a/lib/core/traversalUtils.js
+++ b/lib/core/traversalUtils.js
@@ -41,8 +41,7 @@ export const getICSSExportPropsMap = (ast: gASTNode): classMapType => {
 
 export const getRegularClassesMap = (ast: gASTNode): classMapType => {
   const ruleSets: Array<gASTNode> = [];
-  ast.traverseByType('ruleset', node => ruleSets.push(node));
-
+  ast.traverseByTypes(['class'], node => ruleSets.push(node));
   return fp.compose(
     fp.reduce((result, key) => {
       result[key] = false; // classes haven't been used
@@ -50,10 +49,6 @@ export const getRegularClassesMap = (ast: gASTNode): classMapType => {
     }, {}),
     fp.map('content'),
     fp.filter({ type: 'ident' }),
-    fp.flatMap('content'),
-    fp.filter({ type: 'class' }),
-    fp.flatMap('content'),
-    fp.filter({ type: 'selector' }),
     fp.flatMap('content'),
   )(ruleSets);
 };

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -33,6 +33,7 @@ export type JsNode = {
 // gonzales AST Node Type
 export type gASTNode = {
   traverseByType: Function,
+  traverseByTypes: Function,
 
   type: 'stylesheet'
       | 'ident'

--- a/test/files/not.scss
+++ b/test/files/not.scss
@@ -1,0 +1,13 @@
+.container:not(.wrapper) {
+  min-width: 1024px;
+}
+
+.container :not(.child1) {
+  min-width: 1024px;
+}
+
+.container {
+  :not(.child2) {
+    min-width: 1024px;
+  }
+}

--- a/test/lib/rules/no-undef-class.js
+++ b/test/lib/rules/no-undef-class.js
@@ -263,6 +263,21 @@ ruleTester.run('no-undef-class', rule, {
       `
     }),
     /*
+      :not(.wrapper) should include .wrapper
+    */
+    test({
+      code: `
+        import s from 'test/files/not.scss';
+
+        export default Foo = () => (
+          <div className={s.wrapper}>
+            <div className={s.child1}></div>
+            <div className={s.child2}></div>
+          </div>
+        );
+      `,
+    }),
+    /*
        check if camelCase=true classes work as expected
      */
     test({


### PR DESCRIPTION
Fixes #48

using `traverseByTypes` because I know I'll conflict with #80