### PR TITLE
Fix `no-undef-class` `:global` bug 

### DIFF
--- a/lib/core/traversalUtils.js
+++ b/lib/core/traversalUtils.js
@@ -204,25 +204,67 @@ export const getParentSelectorClassesMap = (ast: gASTNode): classMapType => {
   return classesMap;
 };
 
-/*
-   mutates ast by removing instances of :global
+/**
+ * Mutates the AST by removing `:global` instances.
+ *
+ * For the AST structure:
+ * @see https://github.com/css/gonzales/blob/master/doc/AST.CSSP.en.md
  */
 export const eliminateGlobals = (ast: gASTNode) => {
-  ast.traverse((node, index, parent) => {
-    if (node.type === 'ruleset') {
-      if (
-        fp.compose(
-          fp.negate(fp.isEmpty),
-          fp.find({ type: 'ident', content: 'global' }),
-          fp.get('content'),
-          fp.find({ type: 'pseudoClass' }),
-          fp.get('content'),
-          fp.find({ type: 'selector' }),
-          fp.get('content'),
-        )(node)
-      ) {
-        parent.removeChild(index);
+  // Remove all :global/:global(...) in selectors
+  ast.traverseByType('selector', (selectorNode) => {
+    const selectorContent = selectorNode.content;
+    let hasGlobalWithNoArgs = false;
+    let i = 0;
+    let currNode = selectorContent[i];
+    while (currNode) {
+      if (currNode.is('pseudoClass')) {
+        // Remove all :global/:global(...) and trailing space
+        const identifierNode = currNode.content[0];
+        if (identifierNode && identifierNode.content === 'global') {
+          if (currNode.content.length === 1) hasGlobalWithNoArgs = true;
+          selectorNode.removeChild(i);
+          if (selectorContent[i] && selectorContent[i].is('space')) {
+            selectorNode.removeChild(i);
+          }
+        } else {
+          i++;
+        }
+      } else if (currNode.is('class') && hasGlobalWithNoArgs) {
+        // Remove all class after :global and their trailing space
+        selectorNode.removeChild(i);
+        if (selectorContent[i] && selectorContent[i].is('space')) {
+          selectorNode.removeChild(i);
+        }
+      } else {
+        i++;
       }
+
+      currNode = selectorContent[i];
+    }
+  });
+
+  // Remove all ruleset with no selectors
+  ast.traverseByType('ruleset', (node, index, parent) => {
+    const rulesetContent = node.content;
+
+    // Remove empty selectors and trailing deliminator and space
+    let i = 0;
+    let currNode = rulesetContent[i];
+    while (currNode) {
+      if (currNode.is('selector') && currNode.content.length === 0) {
+        node.removeChild(i);
+        if (rulesetContent[i].is('delimiter')) node.removeChild(i);
+        if (rulesetContent[i].is('space')) node.removeChild(i);
+      } else {
+        i++;
+      }
+      currNode = rulesetContent[i];
+    }
+
+    // Remove the ruleset if no selectors
+    if (rulesetContent.filter((node) => node.is('selector')).length === 0) {
+      parent.removeChild(index);
     }
   });
 };

--- a/test/files/global1.scss
+++ b/test/files/global1.scss
@@ -1,21 +1,25 @@
-.foo {}
+.local1 {}
 
-.bar {
-  :global(.baz) {}
+.local2 {
+  :global(.global1) {}
 }
+
+:global .global1 {}
+
+:global(.global2) {}
 
 :global {
-  .f {
+  .global1 {
 
   }
 }
 
-.baz {
+.local3 {
   :global {
-    .gar {}
+    .global2 {}
   }
 }
 
-:global .as {}
+.local4 :global .global1 .global2 {}
 
-:global(.oiu) {}
+.local5 :global(.global1, .global2) .local6 {}

--- a/test/files/noUndefClass2.scss
+++ b/test/files/noUndefClass2.scss
@@ -1,3 +1,0 @@
-:global(.bold) {
-  font-weight: bold;
-}

--- a/test/lib/core/traversalUtils.test.js
+++ b/test/lib/core/traversalUtils.test.js
@@ -6,132 +6,83 @@ import gonzales from '../../../lib/core/gonzales';
 import { eliminateGlobals } from '../../../lib/core/traversalUtils';
 
 describe('eliminateGlobals()', () => {
-  it('should remove :global block', () => {
-    const content = `
-:global {
-  .foo {}
-}`;
+  describe('resolving :global pseudo class', () => {
+    it('should remove :global operator and the global class', () => {
+      const content = `
+      :global .global {}
+      `;
 
-    const ast = gonzales.parse(
-      content,
-      { syntax: 'scss' }
-    );
+      const ast = gonzales.parse(content, { syntax: 'scss' });
 
-    eliminateGlobals(ast);
+      eliminateGlobals(ast);
 
-    expect(ast.toString()).to.be.equal('\n');
+      expect(ast.toString().trim()).to.be.equal('');
+    });
+
+    it('should remove :global operator and the global classes', () => {
+      const content = `
+      :global .global1 .global2 .global3.global4 {}
+      `;
+
+      const ast = gonzales.parse(content, { syntax: 'scss' });
+
+      eliminateGlobals(ast);
+
+      expect(ast.toString().trim()).to.be.equal('');
+    });
+
+    it('should only remove :global operator and the global classes', () => {
+      const content = `
+      .local1 :global .global1 :local(.local2) .global2 :local(.local3), .local4 {}
+      `;
+
+      const ast = gonzales.parse(content, { syntax: 'scss' });
+
+      eliminateGlobals(ast);
+
+      expect(ast.toString().trim()).to.be.equal(
+        '.local1 :local(.local2) :local(.local3), .local4 {}'
+      );
+    });
   });
 
-  it('should remove :global block, but not local', () => {
-    const content = `
-.bar {}
+  describe('resolving :global() pseudo class', () => {
+    it('should remove :global() pseudo class and its argument class', () => {
+      const content = `
+      :global(.global1) {}
+      `;
 
-:global {
-  .foo {}
-}`;
+      const ast = gonzales.parse(content, { syntax: 'scss' });
 
-    const ast = gonzales.parse(
-      content,
-      { syntax: 'scss' }
-    );
+      eliminateGlobals(ast);
 
-    eliminateGlobals(ast);
+      expect(ast.toString().trim()).to.be.equal('');
+    });
 
-    expect(ast.toString()).to.be.equal(
-      `
-.bar {}
+    it('should remove :global() pseudo class and its argument classes', () => {
+      const content = `
+      :global(.global1) :global(.global2, .global3), :global(.global4.global5) {}
+      `;
 
-`
-    );
-  });
+      const ast = gonzales.parse(content, { syntax: 'scss' });
 
-  it('should remove nested :global block', () => {
-    const content = `
-.bar {}
+      eliminateGlobals(ast);
 
-.baz {
-  :global {
-    .foo {}
-  }
-}`;
+      expect(ast.toString().trim()).to.be.equal('');
+    });
 
-    const ast = gonzales.parse(
-      content,
-      { syntax: 'scss' }
-    );
+    it('should only remove :global() pseudo class and its argument classes', () => {
+      const content = `
+      .local1 :global(.global1) .local2, .local3 :global(.global2, .global3).local4 {}
+      `;
 
-    eliminateGlobals(ast);
+      const ast = gonzales.parse(content, { syntax: 'scss' });
 
-    expect(ast.toString()).to.be.equal(
-      `
-.bar {}
+      eliminateGlobals(ast);
 
-.baz {
-  
-}`
-    );
-  });
-
-  it('should remove :global selector', () => {
-    const content = `
-.bar {}
-
-:global .baz {}`;
-
-    const ast = gonzales.parse(
-      content,
-      { syntax: 'scss' }
-    );
-
-    eliminateGlobals(ast);
-
-    expect(ast.toString()).to.be.equal(
-      `
-.bar {}
-
-`
-    );
-  });
-
-  it('should remove :global selector with multiple classes', () => {
-    const content = `
-.bar {}
-
-:global .baz.foo {}`;
-
-    const ast = gonzales.parse(
-      content,
-      { syntax: 'scss' }
-    );
-
-    eliminateGlobals(ast);
-
-    expect(ast.toString()).to.be.equal(
-      `
-.bar {}
-
-`
-    );
-  });
-
-  it('should remove classes wrapped in :global()', () => {
-    const content = `
-.bar {}
-
-:global(.bar.foo) {}`;
-
-    const ast = gonzales.parse(
-      content,
-      { syntax: 'scss' }
-    );
-
-    eliminateGlobals(ast);
-
-    expect(ast.toString()).to.be.equal(
-      `
-.bar {}
-
-`
-    );
+      expect(ast.toString().trim()).to.be.equal(
+        '.local1 .local2, .local3 .local4 {}'
+      );
+    });
   });
 });

--- a/test/lib/core/traversalUtils.test.js
+++ b/test/lib/core/traversalUtils.test.js
@@ -73,7 +73,7 @@ describe('eliminateGlobals()', () => {
 
     it('should only remove :global() pseudo class and its argument classes', () => {
       const content = `
-      .local1 :global(.global1) .local2, .local3 :global(.global2, .global3).local4 {}
+      .local1 :global(.global1) .local2, .local3 :global(.global2, .global3) :local(.local4) {}
       `;
 
       const ast = gonzales.parse(content, { syntax: 'scss' });
@@ -81,7 +81,7 @@ describe('eliminateGlobals()', () => {
       eliminateGlobals(ast);
 
       expect(ast.toString().trim()).to.be.equal(
-        '.local1 .local2, .local3 .local4 {}'
+        '.local1 .local2, .local3 :local(.local4) {}'
       );
     });
   });

--- a/test/lib/rules/no-undef-class.js
+++ b/test/lib/rules/no-undef-class.js
@@ -226,13 +226,10 @@ ruleTester.run('no-undef-class', rule, {
         import s from './global1.scss';
 
         export default Foo = () => (
-          <div className={s.bar}>
-            <div className={s.baz}>
-              <div className={s.foo}></div>
-            </div>
+          <div className={s.local1, s.local2, s.local3, s.local4, s.local5, s.local6}>
           </div>
         );
-      `
+      `,
     }),
     /*
        ICSS :export pseudo-selector with a correct prop name should not give error
@@ -399,14 +396,16 @@ ruleTester.run('no-undef-class', rule, {
     */
     test({
       code: `
-        import s from './noUndefClass2.scss';
+        import s from './global1.scss';
 
         export default Foo = () => (
-          <div className={s.bold}></div>
+          <div className={s.global1, s.global2, s.global3}></div>
         );
       `,
       errors: [
-        'Class or exported property \'bold\' not found',
+        "Class or exported property 'global1' not found",
+        "Class or exported property 'global2' not found",
+        "Class or exported property 'global3' not found",
       ],
     }),
     /*


### PR DESCRIPTION
Fixes false positive on `:global` in the `no-undef-class` rule https://github.com/atfzl/eslint-plugin-css-modules/issues/14
```html
<!-- Fails with undefined `localClass` -->
<div class="localClass">
  ...
</div>
```
```css
/** Whole selector is removed due to `global:` **/
.localClass global: .globalClass {...}
```
Fixed by only removing the global classes after `:global` and inside `:global(...)`