### PR TITLE
Support animation names

### DIFF
--- a/test/files/animationName.scss
+++ b/test/files/animationName.scss
@@ -1,0 +1,14 @@
+// Used in `className`
+@keyframes animationName1 {}
+
+// Used in other classes
+@keyframes animationName2 {}
+
+.classUsingAnimation1 {
+  animation-name: animationName2;
+}
+
+// Using undefined animation name in another class
+.classUsingAnimation2 {
+  animation-name: undefinedAnimationName;
+}

--- a/test/lib/rules/no-undef-class.test.js
+++ b/test/lib/rules/no-undef-class.test.js
@@ -566,4 +566,43 @@ describe('no-undef-class', function () {
       },
     ].map((testCase) => addFilenameOption(testCase)),
   });
+
+  ruleTester.run('no-undef-class', rule, {
+    valid: [],
+    invalid: [
+      {
+        name: 'should support animation identifiers - using undefinedAnimationName in className',
+        code: `
+        import s from 'test/files/animationName.scss';
+
+        export default Foo = () => (
+          <div>
+            <div className={s.classUsingAnimation1}></div>
+            <div className={s.classUsingAnimation2}></div>
+            <div className={s.undefinedAnimationName}></div>
+          </div>
+        );
+      `,
+        errors: [
+          "Class or exported property 'undefinedAnimationName' not found",
+        ],
+      },
+      {
+        name: 'should support animation identifiers - using undefinedAnimationName in another class',
+        code: `
+        import s from 'test/files/animationName.scss';
+
+        export default Foo = () => (
+          <div>
+            <div className={s.classUsingAnimation1}></div>
+            <div className={s.classUsingAnimation2}></div>
+          </div>
+        );
+      `,
+        errors: [
+          "Class or exported property 'undefinedAnimationName' not found",
+        ],
+      },
+    ].map((testCase) => addFilenameOption(testCase)),
+  });
 });

--- a/test/lib/rules/no-unused-class.test.js
+++ b/test/lib/rules/no-unused-class.test.js
@@ -359,4 +359,39 @@ describe('no-unused-class', function () {
       },
     ].map((testCase) => addFilenameOption(testCase)),
   });
+
+  ruleTester.run('no-unused-class', rule, {
+    valid: [
+      {
+        name: 'should support animation identifiers - animationName1 used in className, animationName2 used in other classes',
+        code: `
+        import s from 'test/files/animationName.scss';
+
+        export default Foo = () => (
+          <div>
+            <div className={s.classUsingAnimation1}></div>
+            <div className={s.classUsingAnimation2}></div>
+            <div className={s.animationName1}></div>
+          </div>
+        );
+      `,
+      },
+    ],
+    invalid: [
+      {
+        name: 'should support animation identifiers - animationName1 not used, animationName2 used in other classes',
+        code: `
+        import s from 'test/files/animationName.scss';
+
+        export default Foo = () => (
+          <div>
+            <div className={s.classUsingAnimation1}></div>
+            <div className={s.classUsingAnimation2}></div>
+          </div>
+        );
+      `,
+        errors: ['Unused classes found in animationName.scss: animationName1'],
+      },
+    ].map((testCase) => addFilenameOption(testCase)),
+  });
 });


### PR DESCRIPTION
https://github.com/atfzl/eslint-plugin-css-modules/issues/49

Per [CSS Modules Spec](https://github.com/css-modules/css-modules/blob/master/README.md#css-modules), animation names like `@keyframes animationName` should be supported:
> A CSS Module is a CSS file in which all class names and animation names are scoped locally by default.